### PR TITLE
Trim when decoding too

### DIFF
--- a/encoder.ts
+++ b/encoder.ts
@@ -36,7 +36,7 @@ export function decodeEmptyLines(text:string, emptyLineMarker?:string, newLine?:
 
     var lines = text.split(/\r?\n/);
 
-    const uncommentedLines = lines.map(line => line == marker ? '' : line);
+    const uncommentedLines = lines.map(line => line.trim() == marker ? '' : line);
     
     return uncommentedLines.join(newLine || EmptyLineEncoder.defaultNewLine);
 }


### PR DESCRIPTION
I couldn't make it work without patching this first. It would encode lines, but it will refuse to decode them even when playing with various line endings. However I'm not sure that is the real fix.